### PR TITLE
feat: Update trust for Firefox

### DIFF
--- a/overrides/Firefox.munki.recipe
+++ b/overrides/Firefox.munki.recipe
@@ -51,7 +51,7 @@ current_user=$(/usr/bin/stat -f "%Su" /dev/console)
 				<key>git_hash</key>
 				<string>a28e56e90ebc52512a4b7ec8fe1981bf02e92bc5</string>
 				<key>path</key>
-				<string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Mozilla/MozillaURLProvider.py</string>
+				<string>~/work/autopkg-ci/autopkg-ci/repos/com.github.autopkg.recipes/Mozilla/MozillaURLProvider.py</string>
 				<key>sha256_hash</key>
 				<string>c4ce035b1a629c4925a80003899fcf39480e5224b3015613440f07ab96211f17</string>
 			</dict>
@@ -63,7 +63,7 @@ current_user=$(/usr/bin/stat -f "%Su" /dev/console)
 				<key>git_hash</key>
 				<string>00f9b0ea8aa77716c0875f9aff6f1281cbf8d84d</string>
 				<key>path</key>
-				<string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Mozilla/Firefox.download.recipe</string>
+				<string>~/work/autopkg-ci/autopkg-ci/repos/com.github.autopkg.recipes/Mozilla/Firefox.download.recipe</string>
 				<key>sha256_hash</key>
 				<string>6d17ddeb226c88af7b4bdef7f981634f2da18403e0ebb86afeb5cfbdf4dc5237</string>
 			</dict>
@@ -72,9 +72,9 @@ current_user=$(/usr/bin/stat -f "%Su" /dev/console)
 				<key>git_hash</key>
 				<string>b8ebd97b7fc92cc4a9dc382ccc2ff8090c1b8f21</string>
 				<key>path</key>
-				<string>~/Library/AutoPkg/RecipeRepos/com.github.autopkg.recipes/Mozilla/Firefox.munki.recipe</string>
+				<string>~/work/autopkg-ci/autopkg-ci/repos/com.github.autopkg.recipes/Mozilla/Firefox.munki.recipe</string>
 				<key>sha256_hash</key>
-				<string>3c0f6aa5c32194c85d4a6ff406525c603ffa5e33776d2509f574a7651fed3967d</string>
+				<string>3c0f6aa5c32194c854a6ff406525c603ffa5e33776d2509f574a7651fed3967d</string>
 			</dict>
 		</dict>
 	</dict>


### PR DESCRIPTION
/Users/runner/work/autopkg-ci/autopkg-ci/overrides/Firefox.munki.recipe: FAILED
    Parent recipe com.github.autopkg.munki.firefox-rc-en_US contents differ from expected.
        Path: /Users/runner/work/autopkg-ci/autopkg-ci/repos/com.github.autopkg.recipes/Mozilla/Firefox.munki.recipe
    
